### PR TITLE
Prefix all variables with lynis_

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I recommend using the *'git'* method as it always installs the latest available 
 Role Variables
 -
 
-- **deploy_method**: Deployment method. Defaults to *'tar'*. Accepted values: *'tar'*, *'git'*, *'pkg'*. Currently supported Linux distros: Debian, Ubuntu, RHEL, Fedora, CentOS, openSuSE and SLES.
+- **lynis_deploy_method**: Deployment method. Defaults to *'tar'*. Accepted values: *'tar'*, *'git'*, *'pkg'*. Currently supported Linux distros: Debian, Ubuntu, RHEL, Fedora, CentOS, openSuSE and SLES.
 - **lynis_home**: Directory where Lynis will be installed. Defaults to *'/opt/lynis'*
 - **lynis_url**: URL to fetch the tar archive from. Defaults to *'https://cisofy.com/files'*
 - **lynis_version**: Version of the tar archive to fetch. Defaults to *'2.4.0'*
@@ -16,12 +16,12 @@ Role Variables
 - **lynis_package_checksum**: Checksum of the tar archive to be downloaded. No valid default, look for it at https://cisofy.com/download/lynis/
 - **lynis_download_dir**: Local directory where the tar archive will be downloaded to. Defaults to *'/tmp'*
 - **lynis_git_repo**: Git repo URL. Defaults to *'https://github.com/CISOfy/lynis'*
-- **cron_hour**: Hour of execution of the cron job. Defaults to *'6'*.
-- **cron_minute**: Minute of execution of the cron job. Defaults to *'30'*.
-- **cron_dow**: Day of week of execution of the cron job. Defaults to *'7'*.
-- **report_from**: Sender email address for the weekly audit report. No valid default, you have to fill it in so the cron job doesn't fail.
-- **report_to**: Receiver email address for the weekly audit report. No valid default, you have to fill it in so the cron job doesn't fail.
-- **tests_to_skip**: Tests to skip in the audit runs. No default, fill it in at your convenience with a list of test codes.
+- **lynis_cron_hour**: Hour of execution of the cron job. Defaults to *'6'*.
+- **lynis_cron_minute**: Minute of execution of the cron job. Defaults to *'30'*.
+- **lynis_cron_dow**: Day of week of execution of the cron job. Defaults to *'7'*.
+- **lynis_report_from**: Sender email address for the weekly audit report. No valid default, you have to fill it in so the cron job doesn't fail.
+- **lynis_report_to**: Receiver email address for the weekly audit report. No valid default, you have to fill it in so the cron job doesn't fail.
+- **lynis_tests_to_skip**: Tests to skip in the audit runs. No default, fill it in at your convenience with a list of test codes.
 
 Example Playbook
 -
@@ -30,30 +30,30 @@ Examples of how to use this role, depending on the deployment method of choice:
 
     - hosts: lynis-tar
       roles:
-         - { role: mablanco.lynis, deploy_method: tar }
+         - { role: mablanco.lynis, lynis_deploy_method: tar }
 
     - hosts: lynis-git
       roles:
-         - { role: mablanco.lynis, deploy_method: git }
+         - { role: mablanco.lynis, lynis_deploy_method: git }
 
     - hosts: lynis-pkg
       roles:
-         - { role: mablanco.lynis, deploy_method: pkg }
+         - { role: mablanco.lynis, lynis_deploy_method: pkg }
 
-You can also use the **deploy_method** variable in your inventory as follows:
+You can also use the **lynis_deploy_method** variable in your inventory as follows:
 
     [lynis-tar]
     server01
 
     [lynis-tar:vars]
-    deploy_method=tar
+    lynis_deploy_method=tar
 
-If you want to skip tests that make no sense in your servers, you can assign the **tasks_to_skip** variable with a list of the tests codes in any of the usual places in Ansible. For example, in the *'vars/main.yml'* file:
+If you want to skip tests that make no sense in your servers, you can assign the **lynis_tests_to_skip** variable with a list of the tests codes in any of the usual places in Ansible. For example, in the *'vars/main.yml'* file:
 
     ---
     # vars file for mablanco.lynis
-    
-    tests_to_skip:
+
+    lynis_tests_to_skip:
       - SSH-7408
       - KRNL-6000
       - HOME-9350

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for mablanco.lynis
 
 # general vars
-deploy_method: 'tar'
+lynis_deploy_method: 'tar'
 lynis_home: '/opt/lynis'
 # tar method vars
 lynis_url: 'https://cisofy.com/files'
@@ -13,11 +13,11 @@ lynis_download_dir: '/tmp'
 # git method vars
 lynis_git_repo: 'https://github.com/CISOfy/lynis'
 # cron job vars
-cron_hour: '6'
-cron_minute: '30'
-cron_dow: '7'
+lynis_cron_hour: '6'
+lynis_cron_minute: '30'
+lynis_cron_dow: '7'
 # cron script vars
-report_from: ''
-report_to: ''
+lynis_report_from: ''
+lynis_report_to: ''
 # lynis custom profile vars
-tests_to_skip: ''
+lynis_tests_to_skip: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,11 @@
     owner: root
     group: root
     state: directory
-  when: deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git" ]
 
 - name: install git cli client
   package: name=git state=latest
-  when: deploy_method == "git"
+  when: lynis_deploy_method == "git"
 
 - name: deploy lynis with git
   git:
@@ -20,15 +20,15 @@
     clone: yes
     dest: "{{ lynis_home }}"
     force: yes
-  when: deploy_method == "git"
+  when: lynis_deploy_method == "git"
 
 - name: deploy lynis with tar
   include: tar.yml
-  when: deploy_method == "tar"
+  when: lynis_deploy_method == "tar"
 
 - name: deploy lynis with distro package
   include: pkg.yml
-  when: deploy_method == "pkg"
+  when: lynis_deploy_method == "pkg"
 
 - name: create man page directory
   file:
@@ -37,7 +37,7 @@
     owner: root
     group: root
     state: directory
-  when: deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git" ]
 
 - name: install man page
   copy:
@@ -47,7 +47,7 @@
     owner: root
     group: root
     remote_src: true
-  when: deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git" ]
 
 - name: create lynis etc directory
   file:
@@ -56,7 +56,7 @@
     owner: root
     group: root
     state: directory
-  when: deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git" ]
 
 - name: install custom profile
   template:
@@ -65,7 +65,7 @@
     owner: root
     group: root
     mode: 0640
-  when: deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git" ]
 
 - name: create lynis log directory
   file:
@@ -86,9 +86,9 @@
 - name: Creates weekly backup cronjob
   cron:
     name: "Launch Lynis security audit"
-    hour: "{{ cron_hour }}"
-    minute: "{{ cron_minute }}"
-    weekday: "{{ cron_dow }}"
+    hour: "{{ lynis_cron_hour }}"
+    minute: "{{ lynis_cron_minute }}"
+    weekday: "{{ lynis_cron_dow }}"
     cron_file: "lynis"
     user: "root"
     job: "/usr/local/bin/lynis_cron.sh 2>&1 | logger"

--- a/templates/lynis.cron.j2
+++ b/templates/lynis.cron.j2
@@ -8,10 +8,10 @@ LOG_DIR="/var/log/lynis"
 REPORT="$LOG_DIR/report-${HOST}.${DATE}.log"
 DATA="$LOG_DIR/report-data-${HOST}.${DATE}.log"
 
-FROM="{{ report_from }}"
-TO="{{ report_to }}"
+FROM="{{ lynis_report_from }}"
+TO="{{ lynis_report_to }}"
 
-{% if deploy_method == "pkg" %}
+{% if lynis_deploy_method == "pkg" %}
 {% if ansible_os_family == 'Debian' %}
 LYNIS_PATH="/usr/sbin/lynis"
 {% else %}
@@ -20,7 +20,7 @@ LYNIS_PATH="/usr/bin/lynis"
 $LYNIS_PATH audit system --auditor "${AUDITOR}" --cronjob > ${REPORT}
 {% else %}
 cd /opt/lynis
-{% if deploy_method == "git" %}
+{% if lynis_deploy_method == "git" %}
 git pull
 {% endif %}
 ./lynis audit system --auditor "${AUDITOR}" --cronjob > ${REPORT}

--- a/templates/lynis.custom.prf.j2
+++ b/templates/lynis.custom.prf.j2
@@ -1,7 +1,7 @@
 # Lynis - Custom scan profile
 
 # Skip a test (one per line)
-{% for item in tests_to_skip %}
+{% for item in lynis_tests_to_skip %}
 skip-test={{ item }}
 {% endfor %}
 


### PR DESCRIPTION
Prefix all variables with the "role name" is a good practice to avoid variable name collision when using multiple roles.