### PR TITLE
Add custom configuration to pkg installed lynis

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
     owner: root
     group: root
     mode: 0640
-  when: lynis_deploy_method in [ "tar", "git" ]
+  when: lynis_deploy_method in [ "tar", "git", "pkg" ]
 
 - name: Lynis | create lynis log directory
   file:


### PR DESCRIPTION
Update lynis configuration for packaged installations to include
"lynis_tests_to_skip" configuration.